### PR TITLE
Restrict APIs to those allowed in app extensions

### DIFF
--- a/CSVParser.xcodeproj/project.pbxproj
+++ b/CSVParser.xcodeproj/project.pbxproj
@@ -310,6 +310,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -376,6 +377,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -434,6 +436,7 @@
 		_ReleaseConf_CSVParser /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = CSVParser.xcodeproj/CSVParser_Info.plist;
@@ -463,6 +466,7 @@
 		"___DebugConf_CSVParser" /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				INFOPLIST_FILE = CSVParser.xcodeproj/CSVParser_Info.plist;


### PR DESCRIPTION
This turns on the build option to restrict API usage to only APIs allow in app extensions. This setting is on the "General" tab of the build settings for each of the CSVParser and CSVParseriOS targets in the project.

Turning this on allows the framework to be included in app extensions on both macOS and iOS.

![image](https://user-images.githubusercontent.com/481406/34752901-00f08374-f583-11e7-9d84-642f975abe6e.png)
